### PR TITLE
CompetitionsController and ThemeFileRenderer

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,10 +5,6 @@ class AdminController < ApplicationController
   before_action :current_competition
   before_action :ensure_current_competition
 
-  rescue_from ActiveRecord::RecordNotFound do
-    render_not_found
-  end
-
   def index
     redirect_to admin_competition_dashboard_index_path(current_competition)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  rescue_from ActiveRecord::RecordNotFound do
+    render_not_found
+  end
+
+  def render_not_found
+    render text: 'not found', status: :not_found
+  end
 end

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -1,0 +1,40 @@
+class CompetitionsController < ApplicationController
+  before_action :load_competition
+  before_action :redirect_if_no_locale
+  before_action :load_locale
+  before_action :load_theme_file
+
+  def theme_file
+    renderer = ThemeFileRenderer.new(@theme_file)
+    render text: renderer.render
+  end
+
+  private
+
+  def load_competition
+    @competition = Competition.find_by!(handle: params[:competition_handle])
+  end
+
+  def load_locale
+    @locale = @competition.locales.find_by!(handle: params[:locale])
+  end
+
+  def load_theme_file
+    filename = params[:theme_file] || 'index'
+    extension = params[:format] || 'html'
+
+    @theme_file = @competition.theme_files.for_filename(
+      filename,
+      @locale.handle,
+      extension
+    ).first!
+  end
+
+  def redirect_if_no_locale
+    return if params[:locale]
+    redirect_to competition_area_path(
+      @competition.handle,
+      @competition.default_locale.handle
+    )
+  end
+end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -31,6 +31,11 @@ class Competition < ActiveRecord::Base
   accepts_nested_attributes_for :locales, allow_destroy: true
   accepts_nested_attributes_for :days, allow_destroy: true
 
+  def default_locale
+    # TODO, store/fetch from cookie
+    locales.first
+  end
+
   private
 
   def delegate_user_is_a_delegate?

--- a/app/models/theme_file.rb
+++ b/app/models/theme_file.rb
@@ -4,4 +4,17 @@ class ThemeFile < ActiveRecord::Base
 
   validates :filename, presence: true
   validates :filename, uniqueness: { scope: :competition_id }, allow_nil: true, allow_blank: true
+
+  scope :for_filename, lambda { |name, locale, extension|
+    filenames = [
+      "#{name}.#{locale}.#{extension}",
+      "#{name}.#{extension}",
+    ]
+
+    order_query_segments = filenames.map do |file|
+      "filename = \"#{ThemeFile.connection.quote_string(file)}\" DESC"
+    end
+
+    where(filename: filenames).order(order_query_segments.join(', '))
+  }
 end

--- a/app/services/theme_file_renderer.rb
+++ b/app/services/theme_file_renderer.rb
@@ -1,0 +1,11 @@
+class ThemeFileRenderer
+  attr_reader :theme_file
+
+  def initialize(theme_file)
+    @theme_file = theme_file
+  end
+
+  def render
+    theme_file.content
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,8 @@ Rails.application.routes.draw do
       resources :theme_files, except: [:show]
     end
   end
+
+  get '/:competition_handle/(:locale/(:theme_file))',
+    to: 'competitions#theme_file',
+    as: 'competition_area'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -119,6 +119,35 @@ def create_competitor(competition)
   competitor
 end
 
+
+def create_associations(competition)
+  create_day(competition)
+  create_day(competition)
+
+  competition.locales.create(handle: 'de')
+  competition.locales.create(handle: 'en')
+
+  10.times do
+    create_event(competition)
+  end
+
+  50.times do
+    create_competitor(competition)
+  end
+
+  competition.theme_files.create!(
+    filename: 'index.html',
+    content: <<-HTML
+<html>
+  <body>
+    <h1>Test!</h1>
+    Welcome to this competition!
+  </body>
+</html>
+    HTML
+  )
+end
+
 def create_user(params)
   user = User.where(params.except(:password, :password_confirmation))
   user.first_or_create!(params.slice(:password, :password_confirmation))
@@ -162,7 +191,7 @@ create_user(
   permission_level: User::PERMISSION_LEVELS[:superadmin]
 )
 
-aachen_open = Competition.create!(
+competition = Competition.create!(
   name: "Aachen Open 2014",
   handle: "aachen-open-2014",
   staff_email: "foo@bar.com",
@@ -171,12 +200,4 @@ aachen_open = Competition.create!(
   country: germany
 )
 
-create_day(aachen_open)
-create_day(aachen_open)
-10.times do
-  create_event(aachen_open)
-end
-
-50.times do
-  create_competitor(aachen_open)
-end
+create_associations(competition)

--- a/test/controllers/competitions_controller_test.rb
+++ b/test/controllers/competitions_controller_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+class CompetitionsControllerTest < ActionController::TestCase
+  setup do
+    @competition = competitions(:aachen_open)
+  end
+
+  test '#theme_file redirects to default locale if none is specified' do
+    get :theme_file, competition_handle: @competition.handle
+    assert_redirected_to competition_area_path(
+      @competition.handle,
+      @competition.default_locale.handle
+    )
+  end
+
+  test '#theme_file renders 404 if competition handle is invalid' do
+    get :theme_file, competition_handle: 'invalid'
+    assert_response :not_found
+  end
+
+  test '#theme_file renders 404 if locale handle is invalid' do
+    get :theme_file, competition_handle: @competition.handle, locale: 'invalid'
+    assert_response :not_found
+  end
+
+  test '#theme_file renders 404 if theme_file is invalid' do
+    get :theme_file,
+      competition_handle: @competition.handle,
+      locale: @competition.default_locale.handle,
+      theme_file: 'invalid'
+
+    assert_response :not_found
+  end
+
+  test '#theme_file renders index theme file if no theme_file is specified' do
+    get :theme_file,
+      competition_handle: @competition.handle,
+      locale: @competition.default_locale.handle
+
+    assert_response :ok
+    assert_equal theme_files(:aachen_open_index).content, @response.body
+  end
+
+  test '#theme_file renders theme file and adds html extension' do
+    get :theme_file,
+      competition_handle: @competition.handle,
+      locale: @competition.default_locale.handle,
+      theme_file: 'index'
+
+    assert_response :ok
+    assert_equal theme_files(:aachen_open_index).content, @response.body
+  end
+
+  test '#theme_file prefers localized theme file filenames if they exist' do
+    @competition.theme_files.create!(
+      filename: 'index.de.html',
+      content: 'german'
+    )
+
+    get :theme_file,
+      competition_handle: @competition.handle,
+      locale: 'de',
+      theme_file: 'index'
+
+    assert_response :ok
+    assert_equal 'german', @response.body
+  end
+end


### PR DESCRIPTION
Very simple version of the competition area rendering.

/ao14/de/foobar renders Aachen Open 2014's foobar.de.html (if it exists, and foobar.html otherwise).

No templating yet, will leave that to another PR.

@timhabermaas 
