### PR TITLE
Competition owner

### DIFF
--- a/app/controllers/admin/competitions_controller.rb
+++ b/app/controllers/admin/competitions_controller.rb
@@ -8,6 +8,7 @@ class Admin::CompetitionsController < AdminController
     :name,
     :handle,
     :delegate_user_id,
+    :owner_user_id,
     :staff_email,
     :staff_name,
     :city_name,

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,6 +11,7 @@ class Admin::UsersController < AdminController
     :password_confirmation,
     :permission_level,
     :delegate,
+    :address,
     permissions_attributes: [:id, :_destroy, :competition_id]
   ]
 
@@ -24,6 +25,7 @@ class Admin::UsersController < AdminController
 
   def edit
     @delegating_competitions = @user.delegating_competitions
+    @owned_competitions = @user.owned_competitions
   end
 
   def create

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -13,6 +13,9 @@ class Competition < ActiveRecord::Base
   belongs_to :country
   validates :country, presence: true
 
+  belongs_to :owner, class_name: 'User', foreign_key: 'owner_user_id'
+  validate :owner_has_permission?
+
   belongs_to :delegate, class_name: 'User', foreign_key: 'delegate_user_id'
   validate :delegate_user_is_a_delegate?
 
@@ -36,6 +39,12 @@ class Competition < ActiveRecord::Base
   def delegate_user_is_a_delegate?
     return unless delegate
     return if delegate.delegate?
-    errors.add(:delegate, 'does not have permissions to be delegate of this competition')
+    errors.add(:delegate, 'does not have permission to be delegate of this competition')
+  end
+
+  def owner_has_permission?
+    return unless owner
+    return if owner.policy.login?(self)
+    errors.add(:owner, 'does not have permission to be the owner of this competition')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,15 @@ class User < ActiveRecord::Base
 
   accepts_nested_attributes_for :permissions, allow_destroy: true
 
-  has_many :delegating_competitions, class_name: 'Competition', foreign_key: 'delegate_user_id', dependent: :nullify
+  has_many :owned_competitions,
+    class_name: 'Competition',
+    foreign_key: 'owner_user_id',
+    dependent: :nullify
+
+  has_many :delegating_competitions,
+    class_name: 'Competition',
+    foreign_key: 'delegate_user_id',
+    dependent: :nullify
 
   scope :delegates, ->{ where(delegate: true) }
 

--- a/app/views/admin/competitions/_form.html.erb
+++ b/app/views/admin/competitions/_form.html.erb
@@ -35,6 +35,13 @@
         </td>
       </tr>
       <tr>
+        <td><%= f.label :owner, 'Owner / official contact:' %></td>
+        <td>
+          <%= f.select :owner_user_id, [["", nil]] + @competition.users.map{ |user| [ user.name, user.id ] } %>
+          <%= help_tooltip "This user's address will be shown in the disclaimer section of this competition's theme" %>
+        </td>
+      </tr>
+      <tr>
         <td><%= f.label :delegate, 'Main WCA delegate:' %></td>
         <td>
           <%= f.select :delegate_user_id, [["", nil]] + User.delegates.map{ |user| [ user.name, user.id ] } %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -23,6 +23,10 @@
         <td><%= f.label :password_confirmation, 'Password confirmation:' %></td>
         <td><%= f.password_field :password_confirmation, placeholder: 'Enter new password again' %></td>
       </tr>
+      <tr>
+        <td><%= f.label :address, 'Address:' %></td>
+        <td><%= f.text_area :address %></td>
+      </tr>
     </table>
   <% end %>
 
@@ -45,6 +49,16 @@
     </table>
   <% end %>
 
+  <% if current_user.policy.change_competition_permissions? %>
+    <%= form_section 'Competition staff permissions' do %>
+      <%= f.fields_for :permissions, @user.permissions.sort_by{ |p| p.competition.name } do |ff| %>
+        <%= ff.hidden_field :competition_id %>
+        <%= ff.check_box :_destroy, { checked: ff.object.persisted? }, '0', '1' %>
+        <%= ff.object.competition.name %><br/>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <% if @user.persisted? && @user.delegate && @delegating_competitions.size > 0 %>
     <%= form_section 'Delegacies' do %>
       <ul>
@@ -55,13 +69,13 @@
     <% end %>
   <% end %>
 
-  <% if current_user.policy.change_competition_permissions? %>
-    <%= form_section 'Competition staff permissions' do %>
-      <%= f.fields_for :permissions, @user.permissions.sort_by{ |p| p.competition.name } do |ff| %>
-        <%= ff.hidden_field :competition_id %>
-        <%= ff.check_box :_destroy, { checked: ff.object.persisted? }, '0', '1' %>
-        <%= ff.object.competition.name %><br/>
-      <% end %>
+  <% if @user.persisted? && @owned_competitions.size > 0 %>
+    <%= form_section 'Owned competitions' do %>
+      <ul>
+        <% @owned_competitions.each do |competition| %>
+          <li><%= link_to competition.name, edit_admin_competition_path(competition) %></li>
+        <% end %>
+      </ul>
     <% end %>
   <% end %>
 

--- a/db/migrate/20141011194803_competition_legal_contact.rb
+++ b/db/migrate/20141011194803_competition_legal_contact.rb
@@ -1,0 +1,6 @@
+class CompetitionLegalContact < ActiveRecord::Migration
+  def change
+    add_column :competitions, :owner_user_id, :integer
+    add_column :users, :address, :text
+  end
+end

--- a/db/migrate/20141011202808_add_foreign_keys.rb
+++ b/db/migrate/20141011202808_add_foreign_keys.rb
@@ -1,0 +1,5 @@
+class AddForeignKeys < ActiveRecord::Migration
+  def change
+    add_foreign_key "competitions", "users", name: "competitions_owner_user_id_fk", column: "owner_user_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140927203709) do
+ActiveRecord::Schema.define(version: 20141011202808) do
 
   create_table "competitions", force: true do |t|
     t.string   "name",                              null: false
@@ -27,12 +27,14 @@ ActiveRecord::Schema.define(version: 20140927203709) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "delegate_user_id"
+    t.integer  "owner_user_id"
   end
 
   add_index "competitions", ["country_id"], name: "competitions_country_id_fk", using: :btree
   add_index "competitions", ["delegate_user_id"], name: "competitions_delegate_user_id_fk", using: :btree
   add_index "competitions", ["handle"], name: "index_competitions_on_handle", unique: true, using: :btree
   add_index "competitions", ["name"], name: "index_competitions_on_name", unique: true, using: :btree
+  add_index "competitions", ["owner_user_id"], name: "competitions_owner_user_id_fk", using: :btree
 
   create_table "competitors", force: true do |t|
     t.integer  "competition_id",                          null: false
@@ -200,12 +202,14 @@ ActiveRecord::Schema.define(version: 20140927203709) do
     t.string   "last_name",                        null: false
     t.boolean  "delegate",         default: false
     t.integer  "permission_level",                 null: false
+    t.text     "address"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
   add_foreign_key "competitions", "countries", name: "competitions_country_id_fk"
   add_foreign_key "competitions", "users", name: "competitions_delegate_user_id_fk", column: "delegate_user_id"
+  add_foreign_key "competitions", "users", name: "competitions_owner_user_id_fk", column: "owner_user_id"
 
   add_foreign_key "competitors", "competitions", name: "competitors_competition_id_fk"
   add_foreign_key "competitors", "countries", name: "competitors_country_id_fk"

--- a/test/controllers/admin/competitions_controller_test.rb
+++ b/test/controllers/admin/competitions_controller_test.rb
@@ -23,7 +23,9 @@ class Admin::CompetitionsControllerTest < ActionController::TestCase
       registration_open: true,
       staff_email: 'ao-winter@cubecomp.de',
       staff_name: 'aachen team',
-      venue_address: 'rwth'
+      venue_address: 'rwth',
+      delegate_user_id: users(:delegate).id,
+      owner_user_id: @competition.users.first.id
     }
   end
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -24,7 +24,8 @@ class Admin::UsersControllerTest < ActionController::TestCase
       last_name: 'Bobsen',
       password: 'foobar',
       password_confirmation: 'foobar',
-      permission_level: User::PERMISSION_LEVELS.values.min
+      permission_level: User::PERMISSION_LEVELS.values.min,
+      address: 'Foo Bar 1, 123 Foo, Germany'
     }
 
     assert_difference('User.count') do
@@ -61,7 +62,8 @@ class Admin::UsersControllerTest < ActionController::TestCase
       first_name: 'Bob',
       last_name: 'Bobsen',
       password: 'foobar',
-      password_confirmation: 'foobar'
+      password_confirmation: 'foobar',
+      address: 'Foo Bar 1, 123 Foo, Germany'
     }
 
     patch :update, id: @user, user: params

--- a/test/models/competition_test.rb
+++ b/test/models/competition_test.rb
@@ -136,4 +136,10 @@ class CompetitionTest < ActiveSupport::TestCase
     @competition.delegate = users(:delegate)
     assert_valid(@competition)
   end
+
+  test 'validates that the owner has permission to login' do
+    @competition.owner = users(:flo)
+    @competition.owner.policy.expects(:login?).with(@competition).returns(false)
+    assert_not_valid(@competition, :owner)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -56,6 +56,17 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'destroying an owner nullifies the column on competition' do
+    competition = competitions(:aachen_open)
+    competition.owner = users(:flo)
+    competition.save!
+
+    assert_no_difference 'Competition.count' do
+      competition.owner.destroy!
+      assert_nil competition.reload.owner_user_id
+    end
+  end
+
   test 'removing delegate attribute from user nullifies the column on competition' do
     competition = competitions(:aachen_open)
     competition.delegate = user = users(:delegate)


### PR DESCRIPTION
In the old software, there is legal contact hardcoded in the templates. This PR adds a feature to simplify that. Users can add an address for themselves and Competitions can have "owners". The owner can then be exposed via a Liquid drop to the templates (https://github.com/fw42/cubecomp/pull/32).

![screen shot 2014-10-11 at 4 29 11 pm](https://cloud.githubusercontent.com/assets/2072686/4604066/5e0686e4-5185-11e4-8278-760aaea8fece.png)

![screen shot 2014-10-11 at 4 31 53 pm](https://cloud.githubusercontent.com/assets/2072686/4604073/c20792fa-5185-11e4-814d-3986c118b6bc.png)

![screen shot 2014-10-11 at 4 32 04 pm](https://cloud.githubusercontent.com/assets/2072686/4604074/c3e20786-5185-11e4-9f7d-482f39a0ade4.png)

@timhabermaas 
