### PR TITLE
Validate that event is not not_for_registration

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -14,12 +14,20 @@ class EventRegistration < ActiveRecord::Base
 
   scope :on_day, ->(day){ joins(:event).where('events.day_id = ?', day) }
 
+  validate :event_for_registration?
+
   private
 
   def competitor_registered_for_event_day?
     return unless competitor && event
     return if competitor.registered_on?(event.day_id)
     errors.add(:base, 'competitor is not registered for the day of the event')
+  end
+
+  def event_for_registration?
+    return unless event
+    return if event.state != 'not_for_registration'
+    errors.add(:event, 'is not for registration')
   end
 
   def competition_ids_match

--- a/test/models/event_registration_test.rb
+++ b/test/models/event_registration_test.rb
@@ -46,4 +46,9 @@ class EventRegistrationTest < ActiveSupport::TestCase
     assert_not_valid(@registration.reload, :base)
     assert_equal ['competitor is not registered for the day of the event'], @registration.errors[:base]
   end
+
+  test 'validates that event is not not_for_registration' do
+    @registration.event.update_attribute(:state, 'not_for_registration')
+    assert_not_valid(@registration, :event)
+  end
 end


### PR DESCRIPTION
Make sure it's not possible to register for an event that is specifically marked as "not for registration" (lunch, winner's ceremony, etc.).

This is already not possible via the UI, but maybe it could happen in some other unforeseen way. Just want to make sure.

@timhabermaas 
