### PR TITLE
Registration table sliders

### DIFF
--- a/app/assets/stylesheets/admin.css.scss
+++ b/app/assets/stylesheets/admin.css.scss
@@ -136,10 +136,18 @@ table.competitors {
   }
 }
 
+$table-highlight: #ffff99;
+
+table.registrations {
+  td.highlight {
+    background-color: $table-highlight !important;
+  }
+}
+
 table.events {
   margin-bottom: 25px;
 
   tr.not_for_registration {
-    background-color: #ffff99;
+    background-color: $table-highlight;
   }
 }

--- a/app/views/admin/competitors/_form.html.erb
+++ b/app/views/admin/competitors/_form.html.erb
@@ -95,67 +95,72 @@
       <p>
         <%=
           radio_button "#{f.object_name}[days][#{day.id}]", :status, 'not_registered',
-            checked: !@competitor.registered_on?(day)
+            checked: !@competitor.registered_on?(day),
+            onclick: 'jQuery("#day_' + day.id.to_s + '").slideUp("slow");'
         %>
         not registered<br/>
 
         <%=
           radio_button "#{f.object_name}[days][#{day.id}]", :status, 'guest',
-            checked: @competitor.guest_on?(day)
+            checked: @competitor.guest_on?(day),
+            onclick: 'jQuery("#day_' + day.id.to_s + '").slideUp("slow");'
         %>
         registered as guest<br/>
 
         <%=
           radio_button "#{f.object_name}[days][#{day.id}]", :status, 'competitor',
-            checked: @competitor.competing_on?(day)
+            checked: @competitor.competing_on?(day),
+            onclick: 'jQuery("#day_' + day.id.to_s + '").slideDown("slow");'
         %>
         registered as competitor<br/>
       </p>
 
-      <table class='default-table'>
-        <thead>
-          <tr>
-            <th>Event</th>
-            <th colspan="3">Registration status</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% current_competition.events.where(day: day).each do |event| %>
+      <div id='day_<%= day.id %>' <% unless @competitor.competing_on?(day) %>style="display: none"<% end %>>
+        <table class='default-table registrations'>
+          <thead>
             <tr>
-              <td>
-                <%= event.name %>
-              </td>
-              <td>
-                <%=
-                  radio_button "#{f.object_name}[days][#{day.id}][events][#{event.id}]",
-                    :status,
-                    'not_registered',
-                    checked: @competitor.event_registration_status(event) == 'not_registered'
-                %>
-                not registered
-              </td>
-              <td>
-                <%=
-                  radio_button "#{f.object_name}[days][#{day.id}][events][#{event.id}]",
-                    :status,
-                    'waiting',
-                    checked: @competitor.event_registration_status(event) == 'waiting'
-                %>
-                waiting
-              </td>
-              <td>
-                <%=
-                  radio_button "#{f.object_name}[days][#{day.id}][events][#{event.id}]",
-                    :status,
-                    'registered',
-                    checked: @competitor.event_registration_status(event) == 'registered'
-                %>
-                registered
-              </td>
+              <th>Event</th>
+              <th colspan="3">Registration status</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% current_competition.events.where(day: day).each do |event| %>
+              <tr>
+                <td>
+                  <%= event.name %>
+                </td>
+                <td <% if @competitor.event_registration_status(event) == 'not_registered' %>class='highlight'<% end %>>
+                  <%=
+                    radio_button "#{f.object_name}[days][#{day.id}][events][#{event.id}]",
+                      :status,
+                      'not_registered',
+                      checked: @competitor.event_registration_status(event) == 'not_registered'
+                  %>
+                  not registered
+                </td>
+                <td <% if @competitor.event_registration_status(event) == 'waiting' %>class='highlight'<% end %>>
+                  <%=
+                    radio_button "#{f.object_name}[days][#{day.id}][events][#{event.id}]",
+                      :status,
+                      'waiting',
+                      checked: @competitor.event_registration_status(event) == 'waiting'
+                  %>
+                  waiting
+                </td>
+                <td <% if @competitor.event_registration_status(event) == 'registered' %>class='highlight'<% end %>>
+                  <%=
+                    radio_button "#{f.object_name}[days][#{day.id}][events][#{event.id}]",
+                      :status,
+                      'registered',
+                      checked: @competitor.event_registration_status(event) == 'registered'
+                  %>
+                  registered
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
Add CSS to highlight the currently selected registration status and add slideDown/slideUp onclick events to hide and show the table if the day registration is changed.

![screen shot 2014-10-26 at 12 20 19 pm](https://cloud.githubusercontent.com/assets/2072686/4783581/19b67276-5d2c-11e4-85ed-abfaefa909d2.png)
