### PR TITLE
Bump jquery-rails plugin and remove custom jQuery since it broke tooltips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'coffee-rails'
 
 # Make sure that sb-admin-2 and jquery-nested-attributes still
 # work before version-bumping jQuery
-gem 'jquery-rails', '= 3.1.2'
+gem 'jquery-rails', '= 4.0.0'
 
 gem 'faraday'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     debugger-linecache (1.2.0)
+    docile (1.1.5)
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
       dotenv (= 1.0.2)
@@ -102,13 +103,14 @@ GEM
     immigrant (0.1.8)
       activerecord (>= 3.0)
       foreigner (>= 1.2.1)
-    jquery-rails (3.1.2)
-      railties (>= 3.0, < 5.0)
+    jquery-rails (4.0.0)
+      rails-dom-testing (~> 1.0)
+      railties (>= 4.2.0.beta, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    letter_opener (1.2.0)
+    letter_opener (1.3.0)
       launchy (~> 2.2)
     liquid (3.0.0)
     loofah (2.0.1)
@@ -189,10 +191,11 @@ GEM
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
     sexp_processor (4.4.4)
-    simplecov (0.7.1)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
       multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
     slim (2.1.0)
       temple (~> 0.6.9)
       tilt (>= 1.3.3, < 2.1)
@@ -241,7 +244,7 @@ DEPENDENCIES
   foreigner
   forgery
   immigrant
-  jquery-rails (= 3.1.2)
+  jquery-rails (= 4.0.0)
   letter_opener
   liquid
   marginalia

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -10,7 +10,6 @@
     <%= stylesheet_link_tag 'admin', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'admin', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'email_template_fetcher', 'data-turbolinks-track' => true %>
-    <%= javascript_include_tag '//code.jquery.com/ui/1.11.2/jquery-ui.js', 'data-turbolinks-track' => true %>
 
     <%= csrf_meta_tags %>
   </head>


### PR DESCRIPTION
Remove jquery-ui since it doesn't seem necessary and because it breaks things (see https://github.com/fw42/cubecomp/pull/47#discussion_r21419825).

Also bump jquery-rails (and some other gems) because why not.
