### PR TITLE
Turbolinks for admin area

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'coffee-rails'
 # Make sure that sb-admin-2 and jquery-nested-attributes still
 # work before version-bumping jQuery
 gem 'jquery-rails', '= 4.0.0'
+gem 'jquery-turbolinks'
 
 gem 'faraday'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0.beta, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.1)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -245,6 +248,7 @@ DEPENDENCIES
   forgery
   immigrant
   jquery-rails (= 4.0.0)
+  jquery-turbolinks
   letter_opener
   liquid
   marginalia

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,4 +1,7 @@
+// Those two have to be loaded in this order
 //= require jquery
+//= require jquery.turbolinks
+
 //= require jquery_ujs
 //= require jquery.nested_attributes
 
@@ -18,3 +21,6 @@
 
 //= require typeahead.jquery
 //= require wca-autocomplete
+
+// This should be the last one to be loaded
+//= require turbolinks


### PR DESCRIPTION
Didn't load Turbolinks so far because it broke the sb-admin-2 bootstrap theme. Turns out there is a gem for that (jquery-turbolinks) that magically fixes stuff.

As far as I can tell, all the other JavaScript stuff still works with this enabled.
