### PR TITLE
Only show events that are for registration

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -55,6 +55,10 @@ class Event < ActiveRecord::Base
 
   validate :validate_cant_be_not_for_registration_if_registrations_exist
 
+  def display_name
+    name || name_short
+  end
+
   def for_registration?
     state != 'not_for_registration'
   end

--- a/app/views/admin/competitors/_form.html.erb
+++ b/app/views/admin/competitors/_form.html.erb
@@ -141,10 +141,10 @@
             </tr>
           </thead>
           <tbody>
-            <% current_competition.events.where(day: day).each do |event| %>
+            <% current_competition.events.select{ |event| event.for_registration? && event.day_id == day.id }.each do |event| %>
               <tr>
                 <td>
-                  <%= event.name %>
+                  <%= event.display_name %>
                 </td>
                 <td <% if @competitor.event_registration_status(event) == 'not_registered' %>class='highlight'<% end %>>
                   <%=

--- a/app/views/admin/dashboard/_events_with_limits.html.erb
+++ b/app/views/admin/dashboard/_events_with_limits.html.erb
@@ -17,7 +17,7 @@
         <% @events_with_limits.each do |event| %>
           <tr>
             <td><%= l(event.day.date, format: :day_only) %></td>
-            <td><%= link_to(event.name_short || event.name, edit_admin_competition_event_path(current_competition, event)) %></td>
+            <td><%= link_to(event.name_short, edit_admin_competition_event_path(current_competition, event)) %></td>
             <td style="width: 300px">
               <div class="progress">
                 <% progress = 100.0 * (event.number_of_confirmed_registrations.to_f / event.max_number_of_registrations.to_f) %>

--- a/app/views/liquid/_registration_form.html.erb
+++ b/app/views/liquid/_registration_form.html.erb
@@ -150,7 +150,7 @@
                 event_label =
                   case event.state
                   when 'open_for_registration'
-                    event.name || event.name_short
+                    event.display_name
                   when 'open_with_waiting_list'
                     "#{event.name} (#{t('registration.waiting_list')})"
                   else

--- a/app/views/liquid/_schedule.html.erb
+++ b/app/views/liquid/_schedule.html.erb
@@ -19,7 +19,7 @@
     <tr>
       <td><%= event.start_time ? event.start_time.strftime("%H:%M") : "&nbsp;".html_safe %></td>
       <td><%= event.end_time ? event.end_time.strftime("%H:%M") : "&nbsp;".html_safe %></td>
-      <td><%= event.name_short || event.name %></td>
+      <td><%= event.name_short %></td>
       <td><%= event.round %></td>
       <td><%= event.timelimit %></td>
       <td>


### PR DESCRIPTION
This fixes https://github.com/fw42/cubecomp/issues/104 and https://github.com/fw42/cubecomp/issues/105.

One issue was that I was showing the name (not the short name) and some events don't have a name (only a short name), which meant they appeared blank. Solution is to show the long name if it exists and otherwise the short name.

Other problem was that the form was showing events that weren't for registration (second rounds, breaks, etc.). Fix is to only show events that are explicitly for registration.

@Laura-O FYI