### PR TITLE
Dont show guests on public page

### DIFF
--- a/app/services/theme_file_renderer.rb
+++ b/app/services/theme_file_renderer.rb
@@ -98,8 +98,7 @@ class ThemeFileRenderer
         template: 'competitors',
         controller: @controller,
         locals: default_locals.reverse_merge({
-          :@competitors => @competition.competitors.confirmed
-            .includes(:country, :day_registrations, :event_registrations, :events),
+          :@competitors => competitors_for_view,
           :@events => @competition.events.for_competitors_table.order(:handle)
         })
       )
@@ -118,5 +117,13 @@ class ThemeFileRenderer
         })
       )
     end
+  end
+
+  def competitors_for_view
+    @competition
+      .competitors
+      .confirmed
+      .includes(:country, :day_registrations, :event_registrations, :events)
+      .select{ |competitors| competitors.event_registrations.size > 0 }
   end
 end


### PR DESCRIPTION
Fixes https://github.com/fw42/cubecomp/issues/115

Only show competitors on the public competitors table if they are registered for at least one event.

@SAuroux