### PR TITLE
Validate email domain MX record

### DIFF
--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -12,6 +12,7 @@ class Competitor < ActiveRecord::Base
 
   validates :email, presence: true
   validates :email, email: true, allow_nil: true, allow_blank: true
+  validates :email, email_dns: true, allow_nil: true, allow_blank: true
 
   def self.valid_birthday_range
     Date.new(1900)..(Time.now.utc - 1.years).to_date

--- a/app/validators/email_dns_validator.rb
+++ b/app/validators/email_dns_validator.rb
@@ -1,0 +1,17 @@
+class EmailDnsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless record.changes.key?(attribute)
+    return unless value =~ EmailValidator::REGEXP
+    return if mx_record?(value.split("@").last)
+    record.errors[attribute] << (options[:message] || 'is not a valid email address')
+  end
+
+  private
+
+  def mx_record?(domain)
+    Resolv::DNS.open do |dns|
+      mx = dns.getresources(domain.to_s, Resolv::DNS::Resource::IN::MX)
+      return mx.any?
+    end
+  end
+end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,6 +1,8 @@
 class EmailValidator < ActiveModel::EachValidator
+  REGEXP = /\A[^,\s]+@[^,\s]+\.[a-zA-Z]+\z/i.freeze
+
   def validate_each(record, attribute, value)
-    return if value =~ /\A[^,\s]+@[^,\s]+\.[a-zA-Z]+\z/i
+    return if value =~ REGEXP
     record.errors[attribute] << (options[:message] || 'is not a valid email address')
   end
 end

--- a/test/models/competitor_test.rb
+++ b/test/models/competitor_test.rb
@@ -66,8 +66,27 @@ class CompetitorTest < ActiveSupport::TestCase
     @competitor.email = 'foobar'
     assert_not_valid(@competitor, :email)
 
-    @competitor.email = 'foo@bar.com'
+    @competitor.email = 'foobar@google.com'
     assert_valid @competitor
+  end
+
+  test 'validates on create that email domain has valid DNS MX record' do
+    competitor = Competitor.new
+    competitor.email = 'email@invalid-domain.foo'
+    assert_not_valid(competitor, :email)
+  end
+
+  test 'validates on update that email domain has valid DNS MX record, but only if email was changed' do
+    @competitor.email = 'email@invalid-domain.foo'
+    @competitor.save!(validate: false)
+    assert_valid(@competitor)
+
+    @competitor.first_name = 'some other unrelated change'
+    @competitor.email = 'email@invalid-domain.foo'
+    assert_valid(@competitor)
+
+    @competitor.email = 'bla@invalid-domain.foo'
+    assert_not_valid(@competitor, :email)
   end
 
   test 'validates presence and sanity of birthday' do


### PR DESCRIPTION
Related to https://github.com/fw42/cubecomp/issues/5.

People would often mistype their email address, often with invalid domain names etc. (from my experience, at least one person per competition does it wrong).

This PR adds MX record validation to emails.