### PR TITLE
Don't redirect back to admin area after competition is updated

### DIFF
--- a/app/controllers/admin/competitions_controller.rb
+++ b/app/controllers/admin/competitions_controller.rb
@@ -65,7 +65,7 @@ class Admin::CompetitionsController < AdminController
 
   def update
     if @competition.update(competition_params)
-      redirect_to admin_competitions_path, notice: 'Competition was successfully updated.'
+      redirect_to edit_admin_competition_path(@competition), notice: 'Competition was successfully updated.'
     else
       render :edit
     end

--- a/test/controllers/admin/competitions_controller_test.rb
+++ b/test/controllers/admin/competitions_controller_test.rb
@@ -125,7 +125,7 @@ class Admin::CompetitionsControllerTest < ActionController::TestCase
 
   test '#update' do
     patch :update, id: @competition.id, competition: @update_params
-    assert_redirected_to admin_competitions_path
+    assert_redirected_to edit_admin_competition_path(@competition)
     assert_attributes(@update_params, @competition.reload)
   end
 


### PR DESCRIPTION
Small bug introduced in https://github.com/fw42/cubecomp/pull/123.

Fixes https://github.com/fw42/cubecomp/issues/132.