### PR TITLE
Don't allow users to lock themselves out

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,6 +7,7 @@ class Admin::UsersController < AdminController
   before_action :ensure_user_can_edit_permissions, only: [:update, :create]
   before_action :ensure_user_can_edit_permission_level, only: [:update, :create]
   before_action :ensure_user_can_edit_delegate_flag, only: [:update, :create]
+  before_action :ensure_user_can_change_active_flag, only: [:update]
 
   skip_before_action :ensure_current_competition
 
@@ -91,6 +92,11 @@ class Admin::UsersController < AdminController
 
   def ensure_user_can_edit_user
     return render_forbidden unless current_user.policy.edit_user?(@user)
+  end
+
+  def ensure_user_can_change_active_flag
+    return unless user_params.key?(:active)
+    render_forbidden unless current_user.policy.disable_user?(@user)
   end
 
   def ensure_user_can_edit_permissions

--- a/app/services/user_policy.rb
+++ b/app/services/user_policy.rb
@@ -42,6 +42,10 @@ class UserPolicy
     higher_permission_level_than?(other_user)
   end
 
+  def disable_user?(other_user)
+    higher_permission_level_than?(other_user)
+  end
+
   def edit_user?(other_user)
     same_user?(other_user) || higher_permission_level_than?(other_user)
   end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -27,16 +27,18 @@
         <td><%= f.label :address, 'Address:' %></td>
         <td><%= f.text_area :address %></td>
       </tr>
-      <tr>
-        <td><%= f.label :active, 'Allowed to log in:' %></td>
-        <td>
-          <%= f.radio_button :active, true%>
-          <%= f.label :active, 'yes', value: true, class: 'checkbox' %>
-          &nbsp;
-          <%= f.radio_button :active, false %>
-          <%= f.label :active, 'no', value: false, class: 'checkbox' %>
-        </td>
-      </tr>
+      <% if current_user.policy.disable_user?(@user) %>
+        <tr>
+          <td><%= f.label :active, 'Allowed to log in:' %></td>
+          <td>
+            <%= f.radio_button :active, true%>
+            <%= f.label :active, 'yes', value: true, class: 'checkbox' %>
+            &nbsp;
+            <%= f.radio_button :active, false %>
+            <%= f.label :active, 'no', value: false, class: 'checkbox' %>
+          </td>
+        </tr>
+      <% end %>
     </table>
   <% end %>
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -149,6 +149,19 @@ class Admin::UsersControllerTest < ActionController::TestCase
     assert_equal false, @user.reload.delegate
   end
 
+  test '#update active with permission' do
+    UserPolicy.any_instance.expects(:disable_user?).returns(true)
+    patch :update, id: @user.id, user: { active: false }
+    assert_equal false, @user.reload.active
+  end
+
+  test '#update active without permission' do
+    UserPolicy.any_instance.expects(:disable_user?).returns(false)
+    patch :update, id: @user.id, user: { active: false }
+    assert_response :forbidden
+    assert_equal true, @user.reload.active
+  end
+
   test "#update when passwords don't match fails" do
     patch :update, id: @user.id, user: { password: 'foofoofoo', password_confirmation: 'barbarbar' }
     assert_response 200


### PR DESCRIPTION
Only allow to change the "Allowed to login" flag if the current user has higher permissions than the one that's being edited. In particular, don't allow users to change their own setting for "Allowed to login".