### PR TITLE
fix bug in competing logic

### DIFF
--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -56,11 +56,16 @@ class Competitor < ActiveRecord::Base
 
   def competing_on?(day_id)
     day_id = day_id.id if day_id.is_a?(Day)
-    event_registrations.select{ |registration| registration.event.day_id == day_id }.size > 0
+    registrations_for_day = event_registrations.select{ |registration| registration.event.day_id == day_id }
+    registrations_for_day.reject(&:waiting?).size > 0
   end
 
   def guest_on?(day_id)
     registered_on?(day_id) && !competing_on?(day_id)
+  end
+
+  def competing?
+    event_registrations.reject(&:waiting).size > 0
   end
 
   def event_registrations_by_day(include_waiting = false)

--- a/app/services/pricing_model/per_competition.rb
+++ b/app/services/pricing_model/per_competition.rb
@@ -2,7 +2,7 @@ class PricingModel::PerCompetition < PricingModel
   def entrance_fee_total
     if @competitor.free_entrance?
       0
-    elsif competing_on_at_least_one_day?
+    elsif @competitor.competing?
       @competition.entrance_fee_competitors
     else
       @competition.entrance_fee_guests
@@ -11,11 +11,5 @@ class PricingModel::PerCompetition < PricingModel
 
   def entrance_fee(_day)
     nil
-  end
-
-  private
-
-  def competing_on_at_least_one_day?
-    @competitor.event_registrations.size > 0
   end
 end

--- a/test/controllers/admin/competitors_controller_test.rb
+++ b/test/controllers/admin/competitors_controller_test.rb
@@ -370,7 +370,6 @@ class Admin::CompetitorsControllerTest < ActionController::TestCase
       end
     end
 
-    assert competitor.reload.competing_on?(event.day)
     assert competitor.reload.event_registrations.where(event: event).first.waiting
   end
 

--- a/test/models/competitor_test.rb
+++ b/test/models/competitor_test.rb
@@ -160,6 +160,7 @@ class CompetitorTest < ActiveSupport::TestCase
     assert_equal false, @competitor.competing_on?(day.id)
     assert_equal false, @competitor.guest_on?(day)
     assert_equal false, @competitor.guest_on?(day.id)
+    assert_equal false, @competitor.competing?
 
     RegistrationService.new(@competitor).register_for_day(day.id)
     assert_equal true, @competitor.registered_on?(day)
@@ -168,14 +169,25 @@ class CompetitorTest < ActiveSupport::TestCase
     assert_equal false, @competitor.competing_on?(day.id)
     assert_equal true, @competitor.guest_on?(day)
     assert_equal true, @competitor.guest_on?(day.id)
+    assert_equal false, @competitor.competing?
 
-    RegistrationService.new(@competitor).register_for_event(day.events.first)
+    RegistrationService.new(@competitor).register_for_event(day.events.first, true)
+    assert_equal true, @competitor.registered_on?(day)
+    assert_equal true, @competitor.registered_on?(day.id)
+    assert_equal false, @competitor.competing_on?(day)
+    assert_equal false, @competitor.competing_on?(day.id)
+    assert_equal true, @competitor.guest_on?(day)
+    assert_equal true, @competitor.guest_on?(day.id)
+    assert_equal false, @competitor.competing?
+
+    RegistrationService.new(@competitor).register_for_event(day.events.first, false)
     assert_equal true, @competitor.registered_on?(day)
     assert_equal true, @competitor.registered_on?(day.id)
     assert_equal true, @competitor.competing_on?(day)
     assert_equal true, @competitor.competing_on?(day.id)
     assert_equal false, @competitor.guest_on?(day)
     assert_equal false, @competitor.guest_on?(day.id)
+    assert_equal true, @competitor.competing?
   end
 
   test 'event_registration_status' do


### PR DESCRIPTION
This fixes a bug where a competitor that is registered for only one event on a day would be considered to be "competing" (i.e. pay the competitor price, not the guest price), even if the event registration is on waiting list.

This PR fixes that and only considers competitors to be "competing" if they are participating in at least one event and are not on the waiting list for that event.