### PR TITLE
Allow everyone to import default themes

### DIFF
--- a/app/controllers/admin/theme_files_controller.rb
+++ b/app/controllers/admin/theme_files_controller.rb
@@ -111,7 +111,6 @@ class Admin::ThemeFilesController < AdminController
 
   def theme_to_import_theme_files_from(theme_id)
     return unless theme_id
-    return :forbidden unless current_user.policy.admin_user_menu?
     Theme.find_by!(id: theme_id)
   end
 

--- a/test/controllers/admin/theme_files/competition_test.rb
+++ b/test/controllers/admin/theme_files/competition_test.rb
@@ -114,7 +114,6 @@ module Admin::ThemeFiles
     end
 
     test '#import_files from theme to competition' do
-      UserPolicy.any_instance.expects(:admin_user_menu?).returns(true)
       from_theme = themes(:fancy)
 
       post :import_files, competition_id: @competition.id, from: {


### PR DESCRIPTION
Fixes a stupid bug that was found by @cubizh where only admins are allowed to import default themes. Everybody should be able to do that (for the competitions they have permission to login to). This PR fixes that.