### PR TITLE
Fix email template form

### DIFF
--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -20,6 +20,7 @@ class Admin::EmailTemplatesController < AdminController
       .group('competitions.id, competitions.name')
       .pluck('competitions.id, competitions.name, COUNT(email_templates.id)')
       .map{ |id, name, count| [ "#{name} (#{count} #{"template".pluralize(count)})", id ] }
+      .select{ |competition| current_user.policy.login?(competition) }
   end
 
   def import_templates

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ActiveRecord::Base
   end
 
   def permission?(competition)
-    permissions.where(competition: competition).exists?
+    permissions.any?{ |permission| permission.competition == competition }
   end
 
   def to_liquid

--- a/app/views/admin/email_templates/import_templates_form.html.erb
+++ b/app/views/admin/email_templates/import_templates_form.html.erb
@@ -1,7 +1,7 @@
 <% page_title 'Import email templates' %>
 
 <% if @options.size == 0 %>
-  There are no email templates available to import right now.
+  There are no email templates available for you to import right now.
 <% else %>
   <%= form_tag(import_templates_admin_competition_email_templates_path) do %>
     <table class='form-table'>


### PR DESCRIPTION
Similar bug as https://github.com/fw42/cubecomp/pull/155, also discovered by @cubizh.

Email templates are only supposed to be importable if you have permission to see the competition. That's on purpose. However, the form shows all competitions and then gives you a "forbidden" error when you actually try to import things.

This PR changes it so that the form only shows the competitions that you have access to login to.