### PR TITLE
{{ venue_map }}

### DIFF
--- a/app/assets/stylesheets/competition_area.css.scss.erb
+++ b/app/assets/stylesheets/competition_area.css.scss.erb
@@ -10,6 +10,11 @@ table {
   }
 }
 
+iframe#venue_map {
+  width: 500px;
+  height: 500px;
+}
+
 table.registration_form {
   input[type='text'],
   input[type='submit'],

--- a/app/services/theme_file_renderer.rb
+++ b/app/services/theme_file_renderer.rb
@@ -94,6 +94,8 @@ class ThemeFileRenderer
       :@news => @locale.news.order("time DESC")
     })
 
+    assigns[:venue_map] = ViewDrop.new(template: 'venue_map', controller: @controller, locals: default_locals)
+
     assign_competitors_view
     assign_registration_form_view
   end

--- a/app/views/liquid/_venue_map.html.erb
+++ b/app/views/liquid/_venue_map.html.erb
@@ -1,0 +1,5 @@
+<iframe
+  id="venue_map"
+  frameborder="0" style="border: 0"
+  src="https://www.google.com/maps/embed/v1/place?key=<%= Cubecomp::Application.config.google_maps_api_key %>&q=<%= URI.encode(@competition.venue_address) %>">
+</iframe>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module Cubecomp
 
     # Sends exception emails to this address in the production environment
     config.exceptions_email = ENV["CUBECOMP_EXCEPTIONS_EMAIL"]
+
+    # Browser API key for the Google Maps Embed API
+    config.google_maps_api_key = ENV['CUBECOMP_GOOGLE_MAPS_API_KEY']
   end
 end


### PR DESCRIPTION
Fixes https://github.com/fw42/cubecomp/issues/163.

@cubizh, FYI, this implements a `{{ venue_map }}` command that renders a map via the Google Maps Embed API. No GPS coordinates necessary, it will just look up the position from the venue address.

Size of the map is 500px by 500px by default, but can be overwritten via CSS (or I can change it if you think it's not a reasonable default).

@sauroux FYI

![screen shot 2015-05-16 at 2 54 35 pm](https://cloud.githubusercontent.com/assets/2072686/7667582/817328f2-fbdb-11e4-9bdf-85ed0644e6d5.png)
