### PR TITLE
Remove event long name

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -2,7 +2,6 @@ class Admin::EventsController < AdminController
   before_action :set_event, only: [:edit, :update, :destroy]
 
   PERMITTED_PARAMS = [
-    :name_short,
     :name,
     :handle,
 

--- a/app/helpers/admin/competitors_helper.rb
+++ b/app/helpers/admin/competitors_helper.rb
@@ -7,7 +7,7 @@ module Admin::CompetitorsHelper
       str << "<br>\n" unless str.blank?
       str << "<b>#{day.date.strftime('%A')}</b><br>\n"
       by_day[day].each do |registration|
-        str << registration.event.name_short
+        str << registration.event.name
         str << ' (waiting)' if registration.waiting
         str << "<br>\n"
       end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,7 @@ class Event < ActiveRecord::Base
 
   has_many :competitors, through: :registrations
 
-  validates :name_short, presence: true
+  validates :name, presence: true
 
   validates :handle, presence: true, if: :for_registration?
   validates :handle,
@@ -43,7 +43,7 @@ class Event < ActiveRecord::Base
   validates :state, presence: true
   validates :state, inclusion: { in: Event::STATES.keys }, allow_nil: true, allow_blank: true
 
-  auto_strip_attributes :name_short, :name, :handle, :timelimit, :format, :round, :proceed
+  auto_strip_attributes :name, :handle, :timelimit, :format, :round, :proceed
 
   scope :for_competitors_table, ->{ where.not(state: 'not_for_registration') }
 
@@ -59,10 +59,6 @@ class Event < ActiveRecord::Base
   }
 
   validate :validate_cant_be_not_for_registration_if_registrations_exist
-
-  def display_name
-    name || name_short
-  end
 
   def for_registration?
     state != 'not_for_registration'

--- a/app/views/admin/competitors/_form.html.erb
+++ b/app/views/admin/competitors/_form.html.erb
@@ -149,7 +149,7 @@
             <% current_competition.events.select{ |event| event.for_registration? && event.day_id == day.id }.each do |event| %>
               <tr>
                 <td>
-                  <%= event.display_name %>
+                  <%= event.name %>
                 </td>
                 <td <% if @competitor.event_registration_status(event) == 'not_registered' %>class='highlight'<% end %>>
                   <%=

--- a/app/views/admin/dashboard/_events_with_limits.html.erb
+++ b/app/views/admin/dashboard/_events_with_limits.html.erb
@@ -17,7 +17,7 @@
         <% @events_with_limits.each do |event| %>
           <tr>
             <td><%= l(event.day.date, format: :day_only) %></td>
-            <td><%= link_to(event.name_short, edit_admin_competition_event_path(current_competition, event)) %></td>
+            <td><%= link_to(event.name, edit_admin_competition_event_path(current_competition, event)) %></td>
             <td style="width: 300px">
               <div class="progress">
                 <% progress = 100.0 * (event.number_of_confirmed_registrations.to_f / event.max_number_of_registrations.to_f) %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -18,7 +18,6 @@
             $("a#standard-wca-event-load-button").click(function(event) {
               index = parseInt($("select#standard-wca-events").val());
               wca_event = wca_events[index];
-              $("#event_name_short").val(wca_event["name_short"]);
               $("#event_name").val(wca_event["name"]);
               $("#event_format").val(wca_event["format"]);
               $("#event_handle").val(wca_event["handle"]);
@@ -34,11 +33,7 @@
   <%= form_section 'Name' do %>
     <table class="form-table">
       <tr>
-        <td><%= f.label :name_short, 'Short:' %></td>
-        <td><%= f.text_field :name_short %></td>
-      </tr>
-      <tr>
-        <td><%= f.label :name, 'Long:' %></td>
+        <td><%= f.label :name, 'Name:' %></td>
         <td><%= f.text_field :name %></td>
       </tr>
       <tr>

--- a/app/views/admin/events/_table.html.erb
+++ b/app/views/admin/events/_table.html.erb
@@ -28,13 +28,7 @@
       <tr class="<%= "not_for_registration" unless event.for_registration? %>">
         <td><%= event.start_time.strftime("%H:%M") %></td>
         <td><%= event.end_time.try!(:strftime, "%H:%M") %></td>
-        <td>
-          <%= event.name_short %>
-          <% if event.name && event.name_short != event.name %>
-            <br/>
-            <small><%= event.name %></small>
-          <% end %>
-        </td>
+        <td><%= event.name %></td>
         <td><%= event.round %></td>
         <td><%= event.timelimit %></td>
         <td>

--- a/app/views/liquid/_registration_form.html.erb
+++ b/app/views/liquid/_registration_form.html.erb
@@ -153,7 +153,7 @@
                 event_label =
                   case event.state
                   when 'open_for_registration'
-                    event.display_name
+                    event.name
                   when 'open_with_waiting_list'
                     "#{event.name} (#{t('registration.waiting_list')})"
                   else

--- a/app/views/liquid/_schedule.html.erb
+++ b/app/views/liquid/_schedule.html.erb
@@ -19,7 +19,7 @@
     <tr>
       <td><%= event.start_time ? event.start_time.strftime("%H:%M") : "&nbsp;".html_safe %></td>
       <td><%= event.end_time ? event.end_time.strftime("%H:%M") : "&nbsp;".html_safe %></td>
-      <td><%= event.name_short %></td>
+      <td><%= event.name %></td>
       <td><%= event.round %></td>
       <td><%= event.timelimit %></td>
       <td>

--- a/db/migrate/20150517162903_drop_name_column.rb
+++ b/db/migrate/20150517162903_drop_name_column.rb
@@ -1,0 +1,6 @@
+class DropNameColumn < ActiveRecord::Migration
+  def change
+    remove_column :events, :name
+    rename_column :events, :name_short, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150516210444) do
+ActiveRecord::Schema.define(version: 20150517162903) do
 
   create_table "competitions", force: :cascade do |t|
     t.string   "name",                     limit: 255,                                            null: false
@@ -132,8 +132,7 @@ ActiveRecord::Schema.define(version: 20150516210444) do
   create_table "events", force: :cascade do |t|
     t.integer  "competition_id",              limit: 4,   null: false
     t.integer  "day_id",                      limit: 4,   null: false
-    t.string   "name_short",                  limit: 255, null: false
-    t.string   "name",                        limit: 255
+    t.string   "name",                        limit: 255, null: false
     t.string   "handle",                      limit: 255
     t.string   "state",                       limit: 255, null: false
     t.integer  "max_number_of_registrations", limit: 4

--- a/db/seeds/example_competition.rb
+++ b/db/seeds/example_competition.rb
@@ -2,23 +2,19 @@ require 'forgery'
 
 EVENTS = [
   {
-    name_short: "3x3x3",
-    name: "Rubik's Cube",
+    name: "3x3x3",
     handle: "3"
   },
   {
-    name_short: "4x4x4",
-    name: "Rubik's Revenge",
+    name: "4x4x4",
     handle: "4"
   },
   {
-    name_short: "5x5x5",
-    name: "Rubik's Professor",
+    name: "5x5x5",
     handle: "5"
   },
   {
-    name_short: "3x3 bld",
-    name: "Rubik's Cube blind",
+    name: "3x3 bld",
     handle: "3b"
   }
 ]

--- a/lib/wca_events.rb
+++ b/lib/wca_events.rb
@@ -1,143 +1,122 @@
 wca_event_definitions = [
   {
-    name_short: "Rubik's Cube",
-    name: "Rubik's Cube (3x3x3)",
+    name: "Rubik's Cube",
     handle: "3",
     wca_handle: "333",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "2x2x2",
-    name: "Rubik's Pocket Cube (2x2x2)",
-    handle: "2",
-    wca_handle: "222",
-    formats: [ "Average of 5", "Best of x" ]
-  },
-  {
-    name_short: "4x4x4",
-    name: "Rubik's Revenge (4x4x4)",
+    name: "4x4 Cube",
     handle: "4",
     wca_handle: "444",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "5x5x5",
-    name: "Rubik's Professor (5x5x5)",
+    name: "5x5 Cube",
     handle: "5",
     wca_handle: "555",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "6x6x6",
-    name: "6x6x6 Cube",
-    handle: "6",
-    wca_handle: "666",
-    formats: [ "Mean of 3", "Best of x" ]
-  },
-  {
-    name_short: "7x7x7",
-    name: "7x7x7 Cube",
-    handle: "7",
-    wca_handle: "777",
-    formats: [ "Mean of 3", "Best of x" ]
-  },
-  {
-    name_short: "Clock",
-    name: "Rubik's Clock",
-    handle: "cl",
-    wca_handle: "clock",
+    name: "2x2 Cube",
+    handle: "2",
+    wca_handle: "222",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "Magic",
-    name: "Rubik's Magic",
-    handle: "m",
-    wca_handle: "magic",
+    name: "3x3 blindfolded",
+    handle: "3b",
+    wca_handle: "333bf",
+    formats: [ "Best of x" ]
+  },
+  {
+    name: "3x3 one-handed",
+    handle: "oh",
+    wca_handle: "333oh",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "Master Magic",
-    name: "Rubik's Master Magic",
-    handle: "mm",
-    wca_handle: "mmagic",
-    formats: [ "Average of 5", "Best of x" ]
+    name: "3x3 fewest moves",
+    handle: "fm",
+    wca_handle: "333fm",
+    formats: [ "Best of x" ]
   },
   {
-    name_short: "Megaminx",
+    name: "3x3 with feet",
+    handle: "ft",
+    wca_handle: "333ft",
+    formats: [ "Best of x", "Mean of 3" ]
+  },
+  {
     name: "Megaminx",
     handle: "mx",
     wca_handle: "minx",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "Pyraminx",
     name: "Pyraminx",
     handle: "py",
     wca_handle: "pyram",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "Skewb",
-    name: "Skewb",
-    handle: "sk",
-    wca_handle: "skewb",
-    formats: [ "Average of 5", "Best of x" ]
-  },
-  {
-    name_short: "Square-1",
     name: "Square-1",
     handle: "s1",
     wca_handle: "sq1",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "3x3x3 OH",
-    name: "Rubik's Cube (3x3x3) One-Handed",
-    handle: "oh",
-    wca_handle: "333oh",
+    name: "Rubik's Clock",
+    handle: "cl",
+    wca_handle: "clock",
     formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "3x3x3 Feet",
-    name: "Rubik's Cube (3x3x3) With Feet",
-    handle: "ft",
-    wca_handle: "333ft",
-    formats: [ "Best of x", "Mean of 3" ]
+    name: "Skewb",
+    handle: "sk",
+    wca_handle: "skewb",
+    formats: [ "Average of 5", "Best of x" ]
   },
   {
-    name_short: "Fewest Moves",
-    name: "Rubik's Cube (3x3x3) Fewest Moves",
-    handle: "fm",
-    wca_handle: "333fm",
-    formats: [ "Best of x" ]
+    name: "6x6 Cube",
+    handle: "6",
+    wca_handle: "666",
+    formats: [ "Mean of 3", "Best of x" ]
   },
   {
-    name_short: "3x3x3 BLD",
-    name: "Rubik's Cube (3x3x3) Blindfolded",
-    handle: "3b",
-    wca_handle: "333bf",
-    formats: [ "Best of x" ]
+    name: "7x7 Cube",
+    handle: "7",
+    wca_handle: "777",
+    formats: [ "Mean of 3", "Best of x" ]
   },
   {
-    name_short: "4x4x4 BLD",
-    name: "Rubik's Revenge (4x4x4) Blindfolded",
+    name: "4x4 blindfolded",
     handle: "4b",
     wca_handle: "444bf",
     formats: [ "Best of x" ]
   },
   {
-    name_short: "5x5x5 BLD",
-    name: "Rubik's Professor (5x5x5) Blindfolded",
+    name: "5x5 blindfolded",
     handle: "5b",
     wca_handle: "555bf",
     formats: [ "Best of x" ]
   },
   {
-    name_short: "3x3x3 MBF",
-    name: "Rubik's Cube (3x3x3) Multiple Blindfolded",
+    name: "3x3 multi blind",
     handle: "mbf",
     wca_handle: "333mbf",
     formats: [ "Best of x" ]
+  },
+
+  {
+    name: "Rubik's Magic",
+    handle: "m",
+    formats: [ "Average of 5", "Best of x" ]
+  },
+  {
+    name: "Rubik's Master Magic",
+    handle: "mm",
+    formats: [ "Average of 5", "Best of x" ]
   }
 ]
 

--- a/test/controllers/admin/events_controller_test.rb
+++ b/test/controllers/admin/events_controller_test.rb
@@ -40,8 +40,7 @@ class Admin::EventsControllerTest < ActionController::TestCase
     params = {
       day_id: days(:aachen_open_day_one).id,
       handle: '222',
-      name: 'Rubiks Pocket Cube',
-      name_short: '2x2x2',
+      name: '2x2 cube',
       length_in_minutes: 60,
       max_number_of_registrations: 42,
       start_time: '15:00',
@@ -66,8 +65,7 @@ class Admin::EventsControllerTest < ActionController::TestCase
     params = {
       day_id: days(:aachen_open_day_two).id,
       handle: '222',
-      name: 'Rubiks Pocket Cube',
-      name_short: '2x2x2',
+      name: '2x2 cube',
       length_in_minutes: 60,
       max_number_of_registrations: 42,
       start_time: '15:00',

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,7 +1,6 @@
 aachen_open_rubiks_cube:
   competition: aachen_open
-  name_short: 3x3x3
-  name: Rubik's Cube
+  name: 3x3x3
   handle: 3
   start_time: 2000-01-01 09:00
   max_number_of_registrations: 42
@@ -10,8 +9,7 @@ aachen_open_rubiks_cube:
 
 aachen_open_rubiks_cube_round_two:
   competition: aachen_open
-  name_short: 3x3x3
-  name: Rubik's Cube
+  name: 3x3x3
   start_time: 2000-01-01 09:00
   state: not_for_registration
   round: 2
@@ -19,8 +17,7 @@ aachen_open_rubiks_cube_round_two:
 
 aachen_open_rubiks_professor:
   competition: aachen_open
-  name_short: 5x5x5
-  name: Rubik's Professor
+  name: 5x5x5
   handle: 5
   start_time: 2000-01-01 10:00
   max_number_of_registrations: 17
@@ -29,8 +26,7 @@ aachen_open_rubiks_professor:
 
 aachen_open_rubiks_revenge_day_two:
   competition: aachen_open
-  name_short: 4x4x4
-  name: Rubik's Revenge
+  name: 4x4x4
   handle: 4
   start_time: 2000-01-01 14:00
   max_number_of_registrations: 17

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -21,12 +21,12 @@ class EventTest < ActiveSupport::TestCase
     assert_not_valid(@event, :day)
   end
 
-  test 'validates presence of name_short' do
-    @event.name_short = nil
-    assert_not_valid(@event, :name_short)
+  test 'validates presence of name' do
+    @event.name = nil
+    assert_not_valid(@event, :name)
 
-    @event.name_short = ''
-    assert_not_valid(@event, :name_short)
+    @event.name = ''
+    assert_not_valid(@event, :name)
   end
 
   test 'validates presence of handle unless not_for_registration' do

--- a/test/services/email_template_renderer_test.rb
+++ b/test/services/email_template_renderer_test.rb
@@ -31,9 +31,9 @@ class EmailTemplateRendererTest < ActiveSupport::TestCase
 
       you are now registered for #{@competition.name} for the following events:
       
-      - Rubik's Cube (#{events(:aachen_open_rubiks_cube).day.date.strftime("%Y-%m-%d")})
+      - 3x3x3 (#{events(:aachen_open_rubiks_cube).day.date.strftime("%Y-%m-%d")})
       
-      - Rubik's Professor (#{events(:aachen_open_rubiks_professor).day.date.strftime("%Y-%m-%d")})
+      - 5x5x5 (#{events(:aachen_open_rubiks_professor).day.date.strftime("%Y-%m-%d")})
       
 
       See you,


### PR DESCRIPTION
Closes https://github.com/fw42/cubecomp/issues/157.

This removes the "long name" attribute of events, from now on, they will only have a "name". This field was kinda useless in retrospect and sometimes the source of confusion.

Also, the "load" button for creating new events will now load the standard WCA event names.

For existing competitions, the long name will just be removed and the old short name will stay the same (so if you already created a competition with event names that are not the WCA standard event names, they will stay the way they are, not get automatically changed).

The only place on the competition website where you could even see the long name before was the registration form and the confirmation emails.

@cubizh @sauroux @Laura-O, all okay with this?