### PR TITLE
Fix month off-by-one in public stats

### DIFF
--- a/app/views/liquid/_stats.html.erb
+++ b/app/views/liquid/_stats.html.erb
@@ -33,7 +33,7 @@ $(document).ready(function() {
         name: '<%= t("stats.competitors") %>',
         data: [
           <% @stats.competing_competitors_by_date.each do |date, number| %>
-            [ Date.UTC(<%= date.year %>, <%= date.month %>, <%= date.day %>), <%= number %> ],
+            [ Date.UTC(<%= date.year %>, <%= date.month %> - 1, <%= date.day %>), <%= number %> ],
           <% end %>
         ],
       },
@@ -41,7 +41,7 @@ $(document).ready(function() {
         name: '<%= t("stats.guests") %>',
         data: [
           <% @stats.guests_by_date.each do |date, number| %>
-            [ Date.UTC(<%= date.year %>, <%= date.month %>, <%= date.day %>), <%= number %> ],
+            [ Date.UTC(<%= date.year %>, <%= date.month %> - 1, <%= date.day %>), <%= number %> ],
           <% end %>
         ]
       }


### PR DESCRIPTION
Fixes https://github.com/fw42/cubecomp/issues/211.

According to [this](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC), the JavaScript `Date.UTC` function wants the month between 0 and 11, but the Ruby `Date#month` method returns it between 1 and 12.

