### PR TITLE
CSV export should include waiting list events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -48,6 +48,8 @@ class Event < ActiveRecord::Base
   scope :for_competitors_table, ->{ where.not(state: 'not_for_registration') }
   scope :wca, ->{ where(handle: WCA_EVENTS.map{ |event| event[:handle] }.uniq) }
 
+  scope :for_registration, ->{ where.not(state: 'not_for_registration') }
+
   scope :with_max_number_of_registrations, lambda {
     select('events.*, COUNT(DISTINCT(competitors.id)) AS number_of_confirmed_registrations')
       .where('max_number_of_registrations IS NOT NULL')

--- a/app/services/csv_service.rb
+++ b/app/services/csv_service.rb
@@ -4,10 +4,13 @@ class CsvService
   end
 
   def handles
-    @handles ||= competition.events
-      .where(state: 'open_for_registration')
+    @handles ||= competition
+      .events
+      .for_registration
       .map{ |event| event.wca_handle || event.handle }
-      .compact.sort.uniq
+      .compact
+      .sort
+      .uniq
   end
 
   def active_competitors

--- a/test/services/csv_service_test.rb
+++ b/test/services/csv_service_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class CsvServiceTest < ActiveSupport::TestCase
+  setup do
+    @competition = competitions(:aachen_open)
+  end
+
+  test "#handles includes events that are waiting or closed" do
+    event = events(:aachen_open_rubiks_cube)
+
+    event.state = 'open_with_waiting_list'
+    event.save!
+    assert service.handles.include?(event.wca_handle)
+
+    event.state = 'registration_closed'
+    event.save!
+    assert service.handles.include?(event.wca_handle)
+  end
+
+  private
+
+  def service
+    CsvService.new(@competition)
+  end
+end


### PR DESCRIPTION
This addresses part of https://github.com/fw42/cubecomp/issues/219. If an event is not open for registration (either because it's open with waiting list or because it was open but now is closed), the CSV export would not include it. This PR fixes that and always includes all events that people were able to register for.

@SAuroux 