### PR TITLE
Fix wca handle mapping

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -46,7 +46,7 @@ class Event < ActiveRecord::Base
   auto_strip_attributes :name, :handle, :timelimit, :format, :round, :proceed
 
   scope :for_competitors_table, ->{ where.not(state: 'not_for_registration') }
-  scope :wca, ->{ where(handle: WCA_EVENTS.map{ |event| event[:handle] }.uniq) }
+  scope :wca, ->{ where(handle: WCA_EVENTS.map{ |event| [ event[:handle], event[:wca_handle] ] }.flatten.compact.uniq) }
 
   scope :for_registration, ->{ where.not(state: 'not_for_registration') }
 
@@ -73,7 +73,11 @@ class Event < ActiveRecord::Base
   end
 
   def wca_handle_index
-    @wca_handle_index ||= WCA_EVENTS.find_index{ |wca_event| handle == wca_event[:handle] }
+    @wca_handle_index ||= begin
+      index = WCA_EVENTS.find_index{ |wca_event| handle == wca_event[:handle] }
+      index ||= WCA_EVENTS.find_index{ |wca_event| handle == wca_event[:wca_handle] }
+      index
+    end
   end
 
   def registrations?

--- a/app/services/theme_file_renderer.rb
+++ b/app/services/theme_file_renderer.rb
@@ -155,7 +155,12 @@ class ThemeFileRenderer
   def locals_for_comparison_view
     events = @competition.events.for_competitors_table.wca
     event = events.detect{ |e| e.wca_handle == @controller.params[:event] } || events.first
-    competitors = event.competitors.confirmed.where.not(wca: nil).includes(:country)
+
+    competitors = if event
+      event.competitors.confirmed.where.not(wca: nil).includes(:country)
+    else
+      []
+    end
 
     {
       :@event => event,

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -137,4 +137,36 @@ class EventTest < ActiveSupport::TestCase
     assert events.all?{ |event| event.max_number_of_registrations >= 0 }
     assert_not_nil events.first.number_of_confirmed_registrations
   end
+
+  test "#wca_handle returns wca handle that matches the given short handle" do
+    event = Event.new
+    event.handle = '3'
+    assert_equal '333', event.wca_handle
+  end
+
+  test "#wca_handle returns wca handle if handle itself is already a wca handle" do
+    event = Event.new
+    event.handle = '333'
+    assert_equal '333', event.wca_handle
+  end
+
+  test "#wca_handle returns nil if handle is unknown" do
+    event = Event.new
+    event.handle = 'foobar'
+    assert_equal nil, event.wca_handle
+  end
+
+  test ".wca returns all events that have a valid wca handle or a handle that can be mapped to a wca handle" do
+    competition = competitions(:aachen_open)
+    events = competition.events.wca
+    assert_equal %w(333 444 555), events.map(&:wca_handle)
+
+    events.first.update_attributes(handle: "333")
+    events = competition.events.wca
+    assert_equal %w(333 444 555), events.map(&:wca_handle)
+
+    events.first.update_attributes(handle: "foobar")
+    events = competition.events.wca
+    assert_equal %w(444 555), events.map(&:wca_handle)
+  end
 end


### PR DESCRIPTION
This should fix https://github.com/fw42/cubecomp/issues/222.

We have short handles (2, 3, 4) and wca handles (222, 333, 444) for events. The shorter ones are for printing in the competitors table, just because they look nicer. The longer ones are used for the CSV export. You specify the short handle for your event and the code knows the long handle already (based on [this mapping](https://github.com/fw42/cubecomp/blob/c1fe0ea6ab0d60252361c7c1cd6d15fedf54f09c/lib/wca_events.rb)).

Previously, if someone would accidentally (or on purpose) use the original WCA handles as the handle for an event, a few things would break (https://github.com/fw42/cubecomp/issues/222 for example).

This PR (hopefully) fixes that by making the mapping a bit smarter (i.e. if no  WCA handle can be found based on the short handle, check if the short handle already is a valid WCA handle).