### PR TITLE
Add stats and comparison to default theme

### DIFF
--- a/db/seeds/themes/default/comparison.html
+++ b/db/seeds/themes/default/comparison.html
@@ -1,0 +1,3 @@
+<h2>{{ "comparison.title" | translate }}</h2>
+
+{{ comparison }}

--- a/db/seeds/themes/default/competitors.html
+++ b/db/seeds/themes/default/competitors.html
@@ -11,4 +11,9 @@ $(document).ready(function() {
 {{ "competitors.title" | translate }}
 </h2>
 
+<p>
+  <a href="{{ 'stats' | theme_file_url }}">{{ "stats.title" | translate }}</a>
+  <a href="{{ 'comparison' | theme_file_url }}">{{ "comparison.title" | translate }}</a>
+</p>
+
 {{ competitors }}

--- a/db/seeds/themes/default/stats.html
+++ b/db/seeds/themes/default/stats.html
@@ -1,0 +1,3 @@
+<h2>{{ "stats.title" | translate }}</h2>
+
+{{ stats }}


### PR DESCRIPTION
In https://github.com/fw42/cubecomp/pull/182 and https://github.com/fw42/cubecomp/pull/149 I added those two features to all existing themes, but for some reason forgot to add it to the default theme. Fixing that here.