### PR TITLE
Custom domain frontpage should only show competitions for that domain

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -61,6 +61,17 @@ class Competition < ActiveRecord::Base
     :venue_address,
     :currency
 
+  def self.custom_domains
+    hash = {}
+
+    where.not(custom_domain: nil).pluck(:custom_domain, :custom_domain_force_ssl).each do |domain, ssl|
+      next if hash[domain] == 'https'
+      hash[domain] = ssl ? 'https' : 'http'
+    end
+
+    hash
+  end
+
   def default_locale
     super || locales.first
   end

--- a/db/migrate/20160408235324_default_force_custom_domain_ssl_to_false.rb
+++ b/db/migrate/20160408235324_default_force_custom_domain_ssl_to_false.rb
@@ -1,0 +1,9 @@
+class DefaultForceCustomDomainSslToFalse < ActiveRecord::Migration
+  def up
+    change_column :competitions, :custom_domain_force_ssl, :boolean, default: false
+  end
+
+  def down
+    change_column :competitions, :custom_domain_force_ssl, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150518180507) do
+ActiveRecord::Schema.define(version: 20160408235324) do
 
   create_table "competitions", force: :cascade do |t|
     t.string   "name",                     limit: 255,                                            null: false
@@ -22,20 +22,20 @@ ActiveRecord::Schema.define(version: 20150518180507) do
     t.string   "city_name_short",          limit: 255
     t.text     "venue_address",            limit: 65535
     t.integer  "country_id",               limit: 4,                                              null: false
-    t.boolean  "cc_staff",                 limit: 1,                              default: false
-    t.boolean  "registration_open",        limit: 1,                              default: false
+    t.boolean  "cc_staff",                                                        default: false
+    t.boolean  "registration_open",                                               default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "delegate_user_id",         limit: 4
     t.integer  "owner_user_id",            limit: 4
     t.integer  "default_locale_id",        limit: 4
     t.string   "currency",                 limit: 255
-    t.boolean  "published",                limit: 1,                              default: false
+    t.boolean  "published",                                                       default: false
     t.decimal  "entrance_fee_competitors",               precision: 10, scale: 2, default: 0.0,   null: false
     t.decimal  "entrance_fee_guests",                    precision: 10, scale: 2, default: 0.0,   null: false
     t.string   "pricing_model",            limit: 255,                                            null: false
     t.string   "custom_domain",            limit: 255
-    t.boolean  "custom_domain_force_ssl",  limit: 1
+    t.boolean  "custom_domain_force_ssl",                                         default: false
   end
 
   add_index "competitions", ["country_id"], name: "competitions_country_id_fk", using: :btree
@@ -53,19 +53,19 @@ ActiveRecord::Schema.define(version: 20150518180507) do
     t.string   "email",                   limit: 255,                   null: false
     t.date     "birthday"
     t.integer  "country_id",              limit: 4,                     null: false
-    t.boolean  "local",                   limit: 1,     default: false
-    t.boolean  "staff",                   limit: 1,     default: false
+    t.boolean  "local",                                 default: false
+    t.boolean  "staff",                                 default: false
     t.text     "user_comment",            limit: 65535
     t.text     "admin_comment",           limit: 65535
-    t.boolean  "free_entrance",           limit: 1,     default: false
+    t.boolean  "free_entrance",                         default: false
     t.text     "free_entrance_reason",    limit: 65535
     t.string   "state",                   limit: 255
-    t.boolean  "confirmation_email_sent", limit: 1,     default: false
-    t.boolean  "paid",                    limit: 1,     default: false
+    t.boolean  "confirmation_email_sent",               default: false
+    t.boolean  "paid",                                  default: false
     t.text     "paid_comment",            limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "male",                    limit: 1
+    t.boolean  "male"
     t.text     "nametag",                 limit: 65535
   end
 
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 20150518180507) do
     t.integer  "competitor_id",  limit: 4,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "waiting",        limit: 1, default: false, null: false
+    t.boolean  "waiting",                  default: false, null: false
   end
 
   add_index "event_registrations", ["competition_id"], name: "index_event_registrations_on_competition_id", using: :btree
@@ -212,11 +212,11 @@ ActiveRecord::Schema.define(version: 20150518180507) do
     t.string   "password_digest",  limit: 255
     t.string   "first_name",       limit: 255,                   null: false
     t.string   "last_name",        limit: 255,                   null: false
-    t.boolean  "delegate",         limit: 1,     default: false
+    t.boolean  "delegate",                       default: false
     t.integer  "permission_level", limit: 4,                     null: false
     t.text     "address",          limit: 65535
     t.integer  "version",          limit: 4,     default: 0,     null: false
-    t.boolean  "active",           limit: 1,     default: true,  null: false
+    t.boolean  "active",                         default: true,  null: false
     t.string   "wca",              limit: 255
   end
 

--- a/test/controllers/front_page_controller_test.rb
+++ b/test/controllers/front_page_controller_test.rb
@@ -1,23 +1,200 @@
 require 'test_helper'
 
 class FrontPageControllerTest < ActionController::TestCase
+  setup do
+    @competition = competitions(:aachen_open)
+    @main_domain = "cubecomp.de"
+  end
+
   test "front page" do
     get :index
     assert_response :ok
   end
 
-  test "front page shows competition iff it's published" do
-    competition = competitions(:aachen_open)
-    regexp = /#{Regexp.escape(competition.name)}/
+  test "#index shows competition iff it's published" do
+    regexp = /#{Regexp.escape(@competition.name)}/
 
-    competition.update_attributes(published: true)
+    @competition.update_attributes(published: true)
     get :index
     assert_response :ok
     assert_match regexp, response.body
 
-    competition.update_attributes(published: false)
+    @competition.update_attributes(published: false)
     get :index
     assert_response :ok
     assert_no_match regexp, response.body
+  end
+
+  test "#index on unknown domain with http redirects to https if main_domain has ssl" do
+    mock_main_domain(true)
+    get :index
+    assert_response :redirect
+    assert_redirected_to "https://#{@main_domain}/"
+  end
+
+  test "#index on unknown domain with http does not redirect to https if main_domain does not have ssl" do
+    mock_main_domain(false)
+    get :index
+    assert_response :redirect
+    assert_redirected_to "http://#{@main_domain}/"
+  end
+
+  test "#index on unknown domain with http does not redirect to https if main_domain protocol is unspecified" do
+    mock_main_domain(nil)
+    get :index
+    assert_response :redirect
+    assert_redirected_to "http://#{@main_domain}/"
+  end
+
+  test "#index on main_domain with http redirects to https if main_domain has ssl" do
+    @request.host = @main_domain
+    mock_main_domain(true)
+    get :index
+    assert_response :redirect
+    assert_redirected_to "https://#{@main_domain}/"
+  end
+
+  test "#index on main_domain with http does not redirect to https if main_domain does not have ssl" do
+    @request.host = @main_domain
+    mock_main_domain(false)
+    get :index
+    assert_response :ok
+  end
+
+  test "#index on main_domain with http does not redirect to https if main_domain protocol is unspecified" do
+    @request.host = @main_domain
+    mock_main_domain(nil)
+    get :index
+    assert_response :ok
+  end
+
+  test "#index on main_domain with https redirects to http if main_domain has no ssl" do
+    @request.host = @main_domain
+    use_https
+    mock_main_domain(false)
+    get :index
+    assert_response :redirect
+    assert_redirected_to "http://#{@main_domain}/"
+  end
+
+  test "#index on main_domain with https does not redirect to http if main_domain does have ssl" do
+    @request.host = @main_domain
+    use_https
+    mock_main_domain(true)
+    get :index
+    assert_response :ok
+  end
+
+  test "#index on main_domain with https does not redirect to http if main_domain protocol is unspecified" do
+    @request.host = @main_domain
+    use_https
+    mock_main_domain(nil)
+    get :index
+    assert_response :ok
+  end
+
+  test "#index on custom domain with http redirects to https if custom domain has ssl" do
+    custom_domain = "foobar.com"
+    @competition.custom_domain = custom_domain
+    @competition.custom_domain_force_ssl = true
+    @competition.save!
+    @request.host = custom_domain
+    get :index
+    assert_response :redirect
+    assert_redirected_to "https://#{custom_domain}/"
+  end
+
+  test "#index on custom domain with http does not redirect to https if custom domain doesn't have ssl" do
+    custom_domain = "foobar.com"
+    @competition.custom_domain = custom_domain
+    @competition.custom_domain_force_ssl = false
+    @competition.save!
+    @request.host = custom_domain
+    get :index
+    assert_response :ok
+  end
+
+  test "#index on custom domain with https does not redirect to http if custom domain has ssl" do
+    custom_domain = "foobar.com"
+    @competition.custom_domain = custom_domain
+    @competition.custom_domain_force_ssl = true
+    @competition.save!
+    @request.host = custom_domain
+    use_https
+    get :index
+    assert_response :ok
+  end
+
+  test "#index on custom domain with https does redirect to http if custom domain does not have ssl" do
+    custom_domain = "foobar.com"
+    @competition.custom_domain = custom_domain
+    @competition.custom_domain_force_ssl = false
+    @competition.save!
+    @request.host = custom_domain
+    use_https
+    get :index
+    assert_response :redirect
+    assert_redirected_to "http://#{custom_domain}/"
+  end
+
+  test "#index on main_domain shows competitions with custom_domain" do
+    regexp = /#{Regexp.escape(@competition.name)}/
+
+    @competition.published = true
+    @competition.custom_domain = "foobar.com"
+    @competition.save!
+
+    @request.host = @competition.custom_domain
+    get :index
+    assert_response :ok
+    assert_match regexp, response.body
+  end
+
+  test "#index on custom_domain does not show competitions with other custom_domain" do
+    regexp = /#{Regexp.escape(@competition.name)}/
+
+    @competition.published = true
+    @competition.custom_domain = "foobar.com"
+    @competition.save!
+
+    other_competition = competitions(:german_open)
+    other_competition.custom_domain = "bla.com"
+    other_competition.save!
+
+    @request.host = other_competition.custom_domain
+    get :index
+    assert_response :ok
+    refute_match regexp, response.body
+  end
+
+  test "#index on custom_domain does not show competitions with no custom_domain" do
+    other_competition = competitions(:german_open)
+    other_competition.published = true
+    other_competition.save!
+
+    regexp = /#{Regexp.escape(other_competition.name)}/
+
+    @competition.published = true
+    @competition.custom_domain = "foobar.com"
+    @competition.save!
+
+    @request.host = @competition.custom_domain
+    get :index
+    assert_response :ok
+    refute_match regexp, response.body
+  end
+
+  private
+
+  def mock_main_domain(ssl)
+    Cubecomp::Application.config.expects(:main_domain).returns(@main_domain)
+
+    protocol = if ssl
+      "https://"
+    elsif !ssl.nil?
+      "http://"
+    end
+
+    Cubecomp::Application.config.expects(:main_domain_protocol).returns(protocol)
   end
 end

--- a/test/models/competition_test.rb
+++ b/test/models/competition_test.rb
@@ -214,4 +214,21 @@ class CompetitionTest < ActiveSupport::TestCase
     @competition.pricing_model = Competition::PRICING_MODELS.keys.first
     assert_valid(@competition)
   end
+
+  test ".custom_domains" do
+    @competition.custom_domain = "foobar.com"
+    @competition.save!
+    assert_equal({ "foobar.com" => 'http' }, Competition.custom_domains)
+
+    other_competition = competitions(:german_open)
+    other_competition.custom_domain = "blabla.de"
+    other_competition.custom_domain_force_ssl = true
+    other_competition.save!
+    assert_equal({ "blabla.de" => 'https', "foobar.com" => 'http' }, Competition.custom_domains)
+
+    other_competition.custom_domain = @competition.custom_domain
+    other_competition.custom_domain_force_ssl = true
+    other_competition.save!
+    assert_equal({ "foobar.com" => 'https' }, Competition.custom_domains)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/fw42/cubecomp/issues/215.

When loading cubecomp's front page via a domain that is the custom domain of at least one competition, this PR makes it so that the front page now only shows competitions that use that custom domain.

Loading cubecomp via the default domain will still show all competitions, even the ones that use custom domains.