### PR TITLE
fix weekday of birthdays

### DIFF
--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -102,8 +102,12 @@ class Competitor < ActiveRecord::Base
     birthday.month == date.month && birthday.day == date.day
   end
 
+  def birthday_on_competition
+    days.detect{ |day| birthday_on?(day.date) }
+  end
+
   def birthday_on_competition?
-    days.any?{ |day| birthday_on?(day.date) }
+    !!birthday_on_competition
   end
 
   def event_registration_status(event)

--- a/app/views/admin/competitors/index.html.erb
+++ b/app/views/admin/competitors/index.html.erb
@@ -87,7 +87,11 @@
           <% end %>
 
           <% if competitor.birthday_on_competition? %>
-            <%= tooltip(icon_image_tag('birthday.png'), "Birthday on #{competitor.birthday.strftime("%A")}") %>
+            <%= tooltip(
+              icon_image_tag('birthday.png'),
+              "Birthday on #{competitor.birthday_on_competition.date.strftime("%A")}"
+              )
+            %>
           <% end %>
 
           <% if competition_number = @anniversaries[competitor.wca ] %>

--- a/test/models/competitor_test.rb
+++ b/test/models/competitor_test.rb
@@ -244,10 +244,10 @@ class CompetitorTest < ActiveSupport::TestCase
     end
   end
 
-  test '#birthday_on?' do
+  test '#birthday_on_competition?' do
     date = @competitor.competition.days.first.date
     @competitor.birthday = date
-    assert @competitor.birthday_on?(date)
+    assert true, @competitor.birthday_on_competition?
   end
 
   test '#wca_url' do

--- a/test/models/competitor_test.rb
+++ b/test/models/competitor_test.rb
@@ -244,6 +244,12 @@ class CompetitorTest < ActiveSupport::TestCase
     end
   end
 
+  test '#birthday_on?' do
+    date = @competitor.competition.days.first.date
+    @competitor.birthday = date
+    assert @competitor.birthday_on?(date)
+  end
+
   test '#birthday_on_competition?' do
     date = @competitor.competition.days.first.date
     @competitor.birthday = date


### PR DESCRIPTION
This should fix #230.

This fix is not perfect as it ignores the possibility that a competition is taking place in two different years.
However, it is unlikely that a competition spans over two years, so in general it should be working as expected.
Feel free to ignore this PR if it doesn't meet your quality standards. :-)