### PR TITLE
Migrate countries

### DIFF
--- a/db/migrate/20170709195655_migrate_countries.rb
+++ b/db/migrate/20170709195655_migrate_countries.rb
@@ -1,0 +1,63 @@
+class MigrateCountries < ActiveRecord::Migration[5.1]
+  CHANGES = {
+    "Aruba" => "Netherlands",
+    "Korea" => "Republic of Korea",
+    "USA" => "United States",
+    "Puerto Rico" => "United States"
+  }
+
+  def up
+    Country.transaction do
+      import_all_missing_countries
+
+      CHANGES.each do |old_name, new_name|
+        puts "Renaming #{old_name} to #{new_name}"
+
+        old_country = Country.find_by(name: old_name)
+        next if old_country.nil?
+
+        new_country = Country.find_by!(name: new_name)
+
+        migrate_country(Competitor, old_country, new_country)
+        migrate_country(Competition, old_country, new_country)
+      end
+
+      destroy_all_old_countries
+    end
+  end
+
+  def down
+  end
+
+  private
+
+  def import_all_missing_countries
+    load Rails.root.join("db/seeds/countries.rb")
+  end
+
+  def migrate_country(model, old_country, new_country)
+    model.where(country_id: old_country.id).find_each do |record|
+      puts "-> Changing #{model} #{record.id} from #{old_country.name} (#{old_country.id}) to #{new_country.name} (#{new_country.id})"
+      record.country = new_country
+      record.save!
+    end
+  end
+
+  def destroy_all_old_countries
+    all_country_names = Country.pluck(:name)
+    wca_country_names = Wca::Country.pluck(:name)
+    old_country_names = all_country_names - wca_country_names
+
+    old_country_names.each do |old_country_name|
+      old_country = Country.find_by!(name: old_country_name)
+
+      competitors = Competitor.where(country_id: old_country.id).size
+      competitions = Competition.where(country_id: old_country.id).size
+      if competitors + competitions > 0
+        raise "Expected country to be unused!"
+      end
+
+      old_country.destroy!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170507160112) do
+ActiveRecord::Schema.define(version: 20170709195655) do
 
   create_table "competitions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name", null: false


### PR DESCRIPTION
Migrate countries to the current version of the list of [wca-states](https://github.com/thewca/wca-regulations/blob/draft/wca-states.md) (also see https://github.com/thewca/worldcubeassociation.org/pull/1650).

Checking our production database, there is exactly four countries that need to be migrated:
```
irb(main):041:0> countries = Country.pluck(:name);
irb(main):042:0* wca_countries = Wca::Country.pluck(:name);
irb(main):043:0* competitor_country_ids = Competitor.pluck('distinct(country_id)');
irb(main):044:0* competition_country_ids = Competition.pluck('distinct(country_id)');
irb(main):045:0* Country.where(name: countries - wca_countries).where(id: competitor_country_ids + competition_country_ids).map(&:name)

=> ["Aruba", "Korea", "Puerto Rico", "USA"]
```
Those countries are renamed as follows (see the code in this PR):
```
CHANGES = {
  "Aruba" => "Netherlands",
  "Korea" => "Republic of Korea",
  "USA" => "United States",
  "Puerto Rico" => "United States"
}
```

The migration consists of the following steps:
* (1) Import all missing countries from the WCA database, i.e. for each country name in the WCA database, create a new country with the same name in our database (unless a country with that name already exists).
* (2) For all competitors and all competitions with one of the above four countries, use the country with the new name instead (note that this does not rename the old country but rather change the country association of the model to the corresponding newly created country).
* (3) Delete all countries in our database for which no country of the same name exists in the WCA database (this will delete 22 countries from our database, none of which should have any competitors or competitions anymore at that point).