### PR TITLE
Fix autocompletion for competitors with two first or last names

### DIFF
--- a/app/assets/javascripts/wca-autocomplete.js.coffee
+++ b/app/assets/javascripts/wca-autocomplete.js.coffee
@@ -31,7 +31,7 @@ $(document).ready ->
   auto.bind "typeahead:selected", (event, object) ->
     names = object.name.split(" ")
     firstName = names[0]
-    lastName = names[1]
+    lastName = names.slice(1, names.length).join(" ")
     country = object.countryId
     gender = object.gender
 


### PR DESCRIPTION
Currently, the autocompletion for competitors who already have a WCA ID just splits the name into an array using whitespace as separator. It then assumes that the first element is the first name and the second element is the last name. So "John Doe Smith" becomes first name: "John", last name: "Doe" and "Smith" is ignored.

This PR fixes this by splitting the string at the first whitespace and making the remaining string the second element in the array. This is still not 100% correct if the competitor has two first names as the second first name and the last name are filled in as the last name. However, I think this is still better than just omitting the last name.

Background: there is a German competitor with two last names who repeatedly registered with only his first last name and I know found out why he does that. ;-)

